### PR TITLE
Fix forums link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
 👋🏻 *signup to test the alpha* ⇒ *[here](https://anytype.io/#join)*
 </br>
 
-[Twitter](https://twitter.com/anytypelabs) · [Discord](https://discord.gg/anytype) · [Forums](community.anytype.io)
+[Twitter](https://twitter.com/anytypelabs) · [Discord](https://discord.gg/anytype) · [Forums](https://community.anytype.io)


### PR DESCRIPTION
Link to forum didn't work. It needed https:// at the beginning of it.

:)